### PR TITLE
Fix multiple query runs in visual mode

### DIFF
--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -188,7 +188,7 @@ fun! g:PipeMySQL_RunLine()
   call delete(s:tempfilename)
 endfun
 
-fun! g:PipeMySQL_RunBlock()
+fun! g:PipeMySQL_RunBlock() range
   let l:shell_command = s:Get_Remote()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()


### PR DESCRIPTION
By default, when you run a query in visual mode, the command is called
once per selected line.  However, by adding the range command, you
indicate to vim that you want to run the command once and you will
handle gathering position information yourself.

The PipeGetSelectedTextAsList() function in pipe.vim already handles
position information, so we only need to add the range modifier to this
function call.
