### PR TITLE
Default preview cursor position to the top

### DIFF
--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -8,6 +8,7 @@ if exists("g:loaded_pipemysqldotvim") || &cp
   finish
 endif
 let g:loaded_pipemysqldotvim = 1
+let g:top_or_bottom = 'top'
 
 " Variables: {{{
 " @brief prefix for variables in buffers, help minimize chance of naming conflict


### PR DESCRIPTION
This PR should be considered **after** https://github.com/NLKNguyen/pipe.vim/pull/1.
This commit defaults the cursor position to the top of
the preview buffer after a query is executed.
