### PR TITLE
add additional variable to receive mysql pager option

### DIFF
--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -33,12 +33,6 @@ if !exists("g:pipemysql_login_info")
   let g:pipemysql_login_info = []
 endif
 
-" @brief string for pager
-if !exists("g:pipemysql_pager")
-  let g:pipemysql_pager = ''
-endif
-" }}}
-
 " Edit Info: {{{
 fun! g:PipeMySQL_SelectPreset()
   let l:list = ["Select login info:"]
@@ -170,6 +164,8 @@ endfun
 fun! s:Get_Pager_Option()
   if exists('g:pipemysql_pager')
     return ' | ' . g:pipemysql_pager
+  endif
+  return ''
 endfun
 " }}}
 

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -9,7 +9,6 @@ if exists("g:loaded_pipemysqldotvim") || &cp
 endif
 let g:loaded_pipemysqldotvim = 1
 let g:pipe_default_cursor_position = 'top'
-
 " Variables: {{{
 " @brief prefix for variables in buffers, help minimize chance of naming conflict
 let s:prefix = 'ac59330d' 
@@ -32,6 +31,11 @@ let s:var_mysql_select_limit     = 'b:' . s:prefix . 'mysql_select_limit'
 " @brief list of preset login info
 if !exists("g:pipemysql_login_info")
   let g:pipemysql_login_info = []
+endif
+
+" @brief string for pager
+if !exists("g:pipe_mysql_pager")
+  let g:pipe_mysql_pager = ''
 endif
 " }}}
 
@@ -163,6 +167,8 @@ fun! s:Get_MySQL_Database()
   return ' ' . g:PipeGetVar(s:var_mysql_database, 'MySQL Database = ') . ' '
 endfun
 
+fun! s:Get_Pager_Option()
+  return g:pipe_mysql_pager
 " }}}
 
 " Run: {{{
@@ -171,7 +177,7 @@ fun! g:PipeMySQL_RunFile()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= ' -t < ' . expand('%:p')
-
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
 endfun
 
@@ -184,7 +190,8 @@ fun! g:PipeMySQL_RunLine(format)
   call writefile([g:PipeGetCurrentLine()], s:tempfilename, 's')
 
   let l:shell_command .= ' --' . a:format . ' < ' . s:tempfilename
-
+  let l:shell_command .= s:Get_Pager_Option()
+  
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun
@@ -203,7 +210,7 @@ fun! g:PipeMySQL_RunBlock(format) range
   call writefile(l:textlist, s:tempfilename, 's')
 
   let l:shell_command .= ' --' . a:format . ' < ' . s:tempfilename
-
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun
@@ -223,7 +230,7 @@ fun! g:PipeMySQL_RunCustom()
   call writefile([l:custom_statement], s:tempfilename, 's')
 
   let l:shell_command .= ' -t < ' . s:tempfilename
-
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -168,7 +168,8 @@ fun! s:Get_MySQL_Database()
 endfun
 
 fun! s:Get_Pager_Option()
-  return ' | ' . g:pipemysql_pager
+  if exists('g:pipemysql_pager')
+    return ' | ' . g:pipemysql_pager
 endfun
 " }}}
 

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -169,6 +169,7 @@ endfun
 
 fun! s:Get_Pager_Option()
   return g:pipe_mysql_pager
+endfun
 " }}}
 
 " Run: {{{
@@ -252,6 +253,7 @@ fun! g:PipeMySQL_TableDefinition()
 
   let l:shell_command .= ' -t < ' . s:tempfilename
 
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun
@@ -271,6 +273,7 @@ fun! g:PipeMySQL_TableDescription()
 
   let l:shell_command .= ' -t < ' . s:tempfilename
 
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun
@@ -301,6 +304,7 @@ fun! g:PipeMySQL_TableSelectAll(...)
 
   let l:shell_command .= ' -t < ' . s:tempfilename
 
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun
@@ -315,6 +319,7 @@ fun! g:PipeMySQL_TableListing()
 
   let l:shell_command .= ' -t < ' . s:tempfilename
 
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun
@@ -366,6 +371,7 @@ fun! g:PipeMySQL_DatabaseListing()
 
   let l:shell_command .= ' -t < ' . s:tempfilename
 
+  let l:shell_command .= s:Get_Pager_Option()
   call g:Pipe(l:shell_command)
   call delete(s:tempfilename)
 endfun

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -163,6 +163,13 @@ fun! s:Get_MySQL_Database()
   return ' ' . g:PipeGetVar(s:var_mysql_database, 'MySQL Database = ') . ' '
 endfun
 
+fun! s:Get_MySQL_Option()
+  if exists('g:pipemysql_option')
+    return g:pipemysql_option
+  endif
+  return ''
+endfun
+
 " }}}
 
 " Run: {{{
@@ -170,6 +177,7 @@ fun! g:PipeMySQL_RunFile()
   let l:shell_command = s:Get_Remote()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
+  let l:shell_command .= s:Get_MySQL_Option()
   let l:shell_command .= ' -t < ' . expand('%:p')
 
   call g:Pipe(l:shell_command)
@@ -180,6 +188,7 @@ fun! g:PipeMySQL_RunLine(format)
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= s:Get_MySQL_Database()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   call writefile([g:PipeGetCurrentLine()], s:tempfilename, 's')
 
@@ -194,6 +203,7 @@ fun! g:PipeMySQL_RunBlock(format) range
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= s:Get_MySQL_Database()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   let l:textlist = g:PipeGetSelectedTextAsList()
   if len(l:textlist) == 0
@@ -213,6 +223,7 @@ fun! g:PipeMySQL_RunCustom()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= s:Get_MySQL_Database()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   let l:custom_statement = g:PipeGetVar(s:var_mysql_custom_statement, "MySQL Statement » ", 11) "11: always prompt
   if l:custom_statement ==? ''
@@ -235,6 +246,7 @@ fun! g:PipeMySQL_TableDefinition()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= s:Get_MySQL_Database()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   let l:table_name = g:PipeGetCurrentWord()
   if l:table_name ==? ''
@@ -254,6 +266,7 @@ fun! g:PipeMySQL_TableDescription()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= s:Get_MySQL_Database()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   let l:table_name = g:PipeGetCurrentWord()
   if l:table_name ==? ''
@@ -303,6 +316,7 @@ fun! g:PipeMySQL_TableListing()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
   let l:shell_command .= s:Get_MySQL_Database()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   call writefile(['show tables;'], s:tempfilename, 's')
 
@@ -354,6 +368,7 @@ fun! g:PipeMySQL_DatabaseListing()
   let l:shell_command = s:Get_Remote()
   let l:shell_command .= ' mysql '
   let l:shell_command .= s:Get_MySQL_Access()
+  let l:shell_command .= s:Get_MySQL_Option()
 
   call writefile(['show databases;'], s:tempfilename, 's')
 

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -34,8 +34,8 @@ if !exists("g:pipemysql_login_info")
 endif
 
 " @brief string for pager
-if !exists("g:pipe_mysql_pager")
-  let g:pipe_mysql_pager = ''
+if !exists("g:pipemysql_pager")
+  let g:pipemysql_pager = ''
 endif
 " }}}
 
@@ -168,7 +168,7 @@ fun! s:Get_MySQL_Database()
 endfun
 
 fun! s:Get_Pager_Option()
-  return g:pipe_mysql_pager
+  return g:pipemysql_pager
 endfun
 " }}}
 

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -153,7 +153,12 @@ fun! s:Get_MySQL_Access()
 
   if l:mysql_username !=? ''
     let l:mysql_password = g:PipeGetVar(s:var_mysql_password, 'MySQL Password = ', 0)
-    let l:login_info .= " -u " . l:mysql_username  . " -p'" . l:mysql_password . "' "
+    if l:mysql_password !=? ''
+      let l:password_option = " -p'" . l:mysql_password . "' "
+    else
+      let l:password_option = ''
+    endif
+    let l:login_info .= " -u " . l:mysql_username  . l:password_option
   endif
 
   return l:login_info

--- a/plugin/pipe-mysql.vim
+++ b/plugin/pipe-mysql.vim
@@ -168,7 +168,7 @@ fun! s:Get_MySQL_Database()
 endfun
 
 fun! s:Get_Pager_Option()
-  return g:pipemysql_pager
+  return ' | ' . g:pipemysql_pager
 endfun
 " }}}
 


### PR DESCRIPTION
mysql client has ability for interactive with linux command

https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-using-pager.html

and combinate with grcat(if you installed and configurated color), we can colorized the result

so by users choice, pass the pager option for pipe-mysql,

example usage:
```vimrc
let g:pipemysql_pager = 'grcat ~/.grcat'

```

result:
![image](https://user-images.githubusercontent.com/3125503/209460313-2967f8f2-b9fd-4a2e-9f6f-8ef428bed038.png)


+pager can be also be used with less, or more to interact with user and data.